### PR TITLE
Fix risky tests and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+# .github/workflows/ci.yml
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
+    with:
+      disable_behat: true
+      disable_grunt: true
+      disable_phpdoc: true

--- a/classes/condition.php
+++ b/classes/condition.php
@@ -93,6 +93,11 @@ class condition extends \core_availability\condition {
             return true;
         }
 
+        // If $ME is null, the path the user is accessing cannot be checked.
+        if (!isset($ME)) {
+            return false;
+        }
+
         // Check rare cases, like webservice/pluginfile.php.
         if (strpos($ME, "webservice/") !== false || strpos($ME, "tokenpluginfile.php") !== false) {
             $token = optional_param('token', '', PARAM_ALPHANUM);

--- a/version.php
+++ b/version.php
@@ -26,6 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->version = 2021060200;
 $plugin->requires = 2016120500; // Moodle 3.2.
+$plugin->supported = [310, 403];
 $plugin->component = 'availability_mobileapp';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release  = '4.0';


### PR DESCRIPTION
Add CI and also resolve the issue detected in a unit test here:

```
1) availability_mobileapp_condition_testcase::test_in_tree
This test printed output: 
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

2) availability_mobileapp_condition_testcase::test_usage
This test printed output: 
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/site/availability/condition/mobileapp/classes/condition.php on line 97
```